### PR TITLE
DUPLO-10508: update README with example for updating multiple services

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ jobs:
             ]
 ```
 
+## Example updating multiple Duplo services
+
+```yaml
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - develop # branch to trigger on
+jobs:
+  deploy:
+    # This example updates 2 services to use the busybox image
+    name: Deploy with DuploCloud
+    runs-on: ubuntu-latest
+    steps:
+      - name: service-update
+        uses: duplocloud/ghactions-service-update@master
+        with:
+          duplo_host: https://mysystem.duplocloud.net
+          duplo_token: ${{ secrets.DUPLO_TOKEN }}
+          use_bulk_api: true
+          tenant: default
+          services: |-
+            [
+              { "Name": "test1", "Image": "busybox:latest" }
+              { "Name": "test2", "Image": "busybox:latest" }
+            ]
+```
+
 ## Example updating an ECS service
 
 ```yaml


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- Added a comprehensive example to the README demonstrating how to update multiple services in DuploCloud using GitHub Actions.
- This example is particularly useful for users looking to perform bulk service updates, showcasing the use of `use_bulk_api` for efficiency.
- The example includes detailed steps, from the trigger branch setup to the configuration of DuploCloud credentials and service details.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add GitHub Actions Example for Bulk Service Update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
README.md

<li>Added a new example for updating multiple Duplo services using GitHub <br>Actions.<br> <li> Demonstrates the use of <code>duplocloud/ghactions-service-update</code> with <br><code>use_bulk_api</code> to update two services to the <code>busybox:latest</code> image.<br> <li> Specifies the trigger branch as <code>develop</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/ghactions-service-update/pull/255/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+28/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

